### PR TITLE
fix(charts): Adding clusterroles for RBAC support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 # How to Contribute
 
-This project is part of Deis. You can find the latest contribution
-guidelines [at the Deis project](https://github.com/deisthree/deis/blob/master/CONTRIBUTING.md).
+This project is part of Hephy. You can find the latest contribution
+guidelines [at the Hephy project](https://github.com/teamhephy/deis/blob/master/CONTRIBUTING.md).
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,4 +1,4 @@
 # Deis Maintainers
 
-This project is part of Deis. The official maintainers documentation is
-located [in the main project](https://github.com/deisthree/deis/blob/master/MAINTAINERS.md).
+This project is part of Hephy. The official maintainers documentation is
+located [in the main project](https://github.com/teamhephy/deis/blob/master/MAINTAINERS.md).

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ that adds a developer-friendly layer to any [Kubernetes][k8s-home] cluster,
 making it easy to deploy and manage applications on your own servers.
 
 For more information about Deis Workflow, please visit the main project page at
-https://github.com/deisthree/workflow.
+https://github.com/teamhephy/workflow.
 
 We welcome your input! If you have feedback on Workflow Manager,
 please [submit an issue][issues]. If you'd like to participate in development,
@@ -55,7 +55,7 @@ an outline.
 ## Docker Based Development Environment
 
 The preferred environment for development uses [the `go-dev` Docker
-image](https://github.com/deisthree/docker-go-dev). The tools described in this
+image](https://github.com/teamhephy/docker-go-dev). The tools described in this
 section are used to build, test, package and release each version of Deis.
 
 To use it yourself, you must have [make](https://www.gnu.org/software/make/)
@@ -86,7 +86,7 @@ core contributors also recognize that some code must be tested at a higher
 level (functional or integration tests, for example).
 
 
-[issues]: https://github.com/deisthree/workflow-manager/issues
-[prs]: https://github.com/deisthree/workflow-manager/pulls
+[issues]: https://github.com/teamhephy/workflow-manager/issues
+[prs]: https://github.com/teamhephy/workflow-manager/pulls
 [k8s-home]: https://kubernetes.io
-[v2.18]: https://github.com/deisthree/workflow/releases/tag/v2.18.0
+[v2.18]: https://github.com/teamhephy/workflow/releases/tag/v2.18.0

--- a/charts/workflow-manager/Chart.yaml
+++ b/charts/workflow-manager/Chart.yaml
@@ -1,5 +1,5 @@
 name: workflow-manager
-home: https://github.com/deisthree/workflow-manager
+home: https://github.com/teamhephy/workflow-manager
 version:  <Will be populated by the ci before publishing the chart>
 description: "Deis Workflow Manager: Cluster First Aid"
 maintainers:

--- a/charts/workflow-manager/templates/_helpers.tmpl
+++ b/charts/workflow-manager/templates/_helpers.tmpl
@@ -1,0 +1,12 @@
+{{/*
+Set apiVersion based on Kubernetes version
+*/}}
+{{- define "rbacAPIVersion" -}}
+{{- if (lt (int (.Capabilities.KubeVersion.Minor)) 6) -}}
+rbac.authorization.k8s.io/v1alpha1
+{{- else if (and (ge (int (.Capabilities.KubeVersion.Minor)) 6) (le (int (.Capabilities.KubeVersion.Minor)) 7)) -}}
+rbac.authorization.k8s.io/v1beta1
+{{- else -}}
+rbac.authorization.k8s.io/v1
+{{- end -}}
+{{- end -}}

--- a/charts/workflow-manager/templates/workflow-manager-clusterrole.yaml
+++ b/charts/workflow-manager/templates/workflow-manager-clusterrole.yaml
@@ -1,0 +1,21 @@
+{{- if (.Values.global.use_rbac) -}}
+{{- if (.Capabilities.APIVersions.Has (include "rbacAPIVersion" .)) -}}
+kind: ClusterRole
+apiVersion: {{ template "rbacAPIVersion" . }}
+metadata:
+  name: deis:deis-workflow-manager
+  labels:
+    app: deis-workflow-manager
+    heritage: deis
+rules:
+- apiGroups: ["extensions", "apps"]
+  resources: ["deployments", "daemonsets"]
+  verbs: ["get", "list"]
+- apiGroups: [""]
+  resources: ["namespaces", "replicationcontrollers"]
+  verbs: ["get", "list"]
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "list", "create", "delete", "update"]
+{{- end -}}
+{{- end -}}

--- a/charts/workflow-manager/templates/workflow-manager-clusterrolebinding.yaml
+++ b/charts/workflow-manager/templates/workflow-manager-clusterrolebinding.yaml
@@ -1,0 +1,19 @@
+{{- if (.Values.global.use_rbac) -}}
+{{- if (.Capabilities.APIVersions.Has (include "rbacAPIVersion" .)) -}}
+kind: ClusterRoleBinding
+apiVersion: {{ template "rbacAPIVersion" . }}
+metadata:
+  name: deis:deis-workflow-manager
+  labels:
+    app: deis-workflow-manager
+    heritage: deis
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: deis:deis-workflow-manager
+subjects:
+- kind: ServiceAccount
+  name: deis-workflow-manager
+  namespace: {{ .Release.Namespace }}
+{{- end -}}
+{{- end -}}

--- a/data/data_test.go
+++ b/data/data_test.go
@@ -113,7 +113,7 @@ func TestAddUpdateData(t *testing.T) {
 	err := AddUpdateData(&mockCluster, mocks.LatestMockData{})
 	assert.NoErr(t, err)
 	//TODO: when newestVersion is implemented, actually test for the addition of "UpdateAvailable" fields.
-	// tracked in https://github.com/deisthree/workflow-manager/issues/52
+	// tracked in https://github.com/teamhephy/workflow-manager/issues/52
 }
 
 func TestGetInstalled(t *testing.T) {


### PR DESCRIPTION
Fixing a mistake caught in Hephy Workflow v2.19.0 release - charts need clusterroles and clusterrolebindings to be created if using RBAC. Also fixed the github teamhephy org links.